### PR TITLE
Add support for the new Realtime API including Broadcast and Presence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@
 /Postgrest/build/
 /Storage/build/
 /Realtime/build/
+/Realtime/src/desktopMain/Test.kt
 .idea
 local.properties

--- a/Realtime/build.gradle.kts
+++ b/Realtime/build.gradle.kts
@@ -48,7 +48,12 @@ kotlin {
                 api("io.ktor:ktor-client-websockets:${Versions.KTOR}")
             }
         }
-        val desktopMain by getting
+        val desktopMain by getting {
+            dependencies {
+                //logback-classic
+                // https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
+            }
+        }
         val androidMain by getting
         val webMain by getting
     }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supacompose/realtime/RealtimeJoinPayload.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supacompose/realtime/RealtimeJoinPayload.kt
@@ -1,0 +1,28 @@
+package io.github.jan.supacompose.realtime
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RealtimeJoinPayload(
+    val config: RealtimeJoinConfig,
+    @SerialName("access_token")
+    val accessToken: String = ""
+)
+
+@Serializable
+data class RealtimeJoinConfig(
+    val broadcast: BroadcastJoinConfig,
+    val presence: PresenceJoinConfig,
+    @SerialName("postgres_changes")
+    val postgrestChanges: List<PostgresJoinConfig>
+)
+
+@Serializable
+data class BroadcastJoinConfig(val ack: Boolean, val self: Boolean)
+
+@Serializable
+data class PresenceJoinConfig(val key: String)
+
+@Serializable
+data class PostgresJoinConfig(val schema: String, val table: String? = null, val filter: String? = null, val event: String, val id: String = "")

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supacompose/realtime/events/EventListener.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supacompose/realtime/events/EventListener.kt
@@ -1,5 +1,7 @@
 package io.github.jan.supacompose.realtime.events
 
+import io.github.jan.supacompose.realtime.events.actions.ChannelAction
+
 /**
  * An event listener for [ChannelAction]s
  */

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supacompose/realtime/events/actions/BroadcastAction.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supacompose/realtime/events/actions/BroadcastAction.kt
@@ -1,0 +1,23 @@
+package io.github.jan.supacompose.realtime.events.actions
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+
+class BroadcastAction(val event: String, val data: JsonObject): ChannelAction
+
+/**
+ * Decodes [BroadcastAction.data] as [T] and returns it or returns null when it cannot be decoded as [T]
+ */
+inline fun <reified T> BroadcastAction.decodeDataOrNull(json: Json = Json): T? {
+    return try {
+        json.decodeFromJsonElement<T>(data)
+    } catch (e: Exception) {
+        null
+    }
+}
+
+/**
+ * Decodes [HasRecord.record] as [T] and returns it
+ */
+inline fun <reified T> BroadcastAction.decodeData(json: Json = Json) = json.decodeFromJsonElement<T>(data)

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supacompose/realtime/events/actions/ChannelAction.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supacompose/realtime/events/actions/ChannelAction.kt
@@ -1,0 +1,9 @@
+package io.github.jan.supacompose.realtime.events.actions
+
+import io.github.jan.supacompose.realtime.RealtimeChannel
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * A channel action is an event received through a [RealtimeChannel]
+ */
+sealed interface ChannelAction

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supacompose/realtime/events/actions/PostgresAction.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supacompose/realtime/events/actions/PostgresAction.kt
@@ -1,5 +1,8 @@
-package io.github.jan.supacompose.realtime.events
+package io.github.jan.supacompose.realtime.events.actions
 
+import io.github.jan.supacompose.realtime.RealtimeChannelBuilder
+import io.github.jan.supacompose.realtime.annotiations.ChannelDsl
+import io.github.jan.supacompose.realtime.events.EventListener
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -31,8 +34,7 @@ interface HasOldRecord {
     val oldRecord: JsonObject
 }
 
-
-sealed interface ChannelAction {
+sealed interface PostgresAction: ChannelAction {
 
     /**
      * Contains data of the row's columns
@@ -50,7 +52,7 @@ sealed interface ChannelAction {
         override val columns: List<Column>,
         @SerialName("commit_timestamp")
         override val commitTimestamp: Instant,
-    ) : ChannelAction, HasRecord
+    ) : PostgresAction, HasRecord
 
     @Serializable
     data class Update(
@@ -60,7 +62,7 @@ sealed interface ChannelAction {
         override val columns: List<Column>,
         @SerialName("commit_timestamp")
         override val commitTimestamp: Instant,
-    ) : ChannelAction, HasRecord, HasOldRecord
+    ) : PostgresAction, HasRecord, HasOldRecord
 
     @Serializable
     data class Delete(
@@ -69,7 +71,7 @@ sealed interface ChannelAction {
         override val columns: List<Column>,
         @SerialName("commit_timestamp")
         override val commitTimestamp: Instant,
-    ) : ChannelAction, HasOldRecord
+    ) : PostgresAction, HasOldRecord
 
     @Serializable
     data class Select(
@@ -77,7 +79,7 @@ sealed interface ChannelAction {
         override val columns: List<Column>,
         @SerialName("commit_timestamp")
         override val commitTimestamp: Instant,
-    ) : ChannelAction, HasRecord
+    ) : PostgresAction, HasRecord
 
 }
 
@@ -86,7 +88,7 @@ sealed interface ChannelAction {
  */
 inline fun <reified T> HasRecord.decodeRecordOrNull(json: Json = Json): T? {
     return try {
-        record.let { json.decodeFromJsonElement<T>(it) }
+        json.decodeFromJsonElement<T>(record)
     } catch (e: Exception) {
         null
     }
@@ -97,7 +99,7 @@ inline fun <reified T> HasRecord.decodeRecordOrNull(json: Json = Json): T? {
  */
 inline fun <reified T> HasOldRecord.decodeOldRecordOrNull(json: Json = Json): T? {
     return try {
-        oldRecord.let { json.decodeFromJsonElement<T>(it) }
+        json.decodeFromJsonElement<T>(oldRecord)
     } catch (e: Exception) {
         null
     }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supacompose/realtime/events/receiver/PostgresReceiver.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supacompose/realtime/events/receiver/PostgresReceiver.kt
@@ -1,0 +1,48 @@
+package io.github.jan.supacompose.realtime.events.receiver
+
+import io.github.jan.supacompose.realtime.PostgresJoinConfig
+import io.github.jan.supacompose.realtime.RealtimeBinding
+import io.github.jan.supacompose.realtime.events.actions.PostgresAction
+
+class PostgresReceiver {
+
+    var schema: String = ""
+    var table: String? = null
+    var filter: String? = null
+    private var event = "*"
+    private var handler: Any.() -> Unit = {}
+
+    fun update(handler: PostgresAction.Update.() -> Unit) {
+        event = "UPDATE"
+        this.handler = {
+            handler(this as? PostgresAction.Update ?: throw IllegalStateException("Not a PostgresAction.Update"))
+        }
+    }
+
+    fun insert(handler: PostgresAction.Insert.() -> Unit) {
+        event = "INSERT"
+        this.handler = {
+            handler(this as? PostgresAction.Insert ?: throw IllegalStateException("Not a PostgresAction.Insert"))
+        }
+    }
+
+    fun delete(handler: PostgresAction.Delete.() -> Unit) {
+        event = "DELETE"
+        this.handler = {
+            handler(this as? PostgresAction.Delete ?: throw IllegalStateException("Not a PostgresAction.Delete"))
+        }
+    }
+
+    fun select(handler: PostgresAction.Select.() -> Unit) {
+        event = "SELECT"
+        this.handler = {
+            handler(this as? PostgresAction.Select ?: throw IllegalStateException("Not a PostgresAction.Select"))
+        }
+    }
+
+    fun toBinding() = RealtimeBinding.PostgrestRealtimeBinding(
+        PostgresJoinConfig(schema, table, filter, event),
+        handler
+    )
+
+}

--- a/desktopDemo/src/jvmMain/kotlin/Main.kt
+++ b/desktopDemo/src/jvmMain/kotlin/Main.kt
@@ -71,11 +71,10 @@ suspend fun main() {
                             schema = "public"
 
                             on<ChannelAction.Insert> {
-
+                                println(record)
                             }
 
                             onAll {
-                                println(oldRecord)
                             }
                         }
                     }


### PR DESCRIPTION
The new realtime api is now available. The update changes and adds a few things:
- Everything is now a channel
- A channel has a unique id
- Multiple clients can connect to the same channel with the same id
- You can send broadcasts and every client within the same channel will receive this broadcast (ignoring the database step and send it directly to other clients)
- You can still listen for database changes
- Presence (TODO)

Currently the new syntax looks like this:
```kotlin
val channel = supabaseClient.realtime.createAndJoinChannel("#random") {

    onPostgrestChange {
        schema = "public"
        table = "test"

        update { //you can  only listen for one specific event or all (but not multiple like before)
            println(record)
        }
   }
     
   onPostgrestChange {
        schema = "public"
        table = "test"

        delete {
            println(oldRecord)
        }
   }
   
   //listen for broadcasts under the event "position" 
   onBroadcast<Position>("position") { //this: Position
        //update other players position on the screen
   }

   //<Presence> (soon)
}

channel.broadcast("position", Position(20, 30)) //broadcast your positon to other clients
```