### PR TITLE
Add support for Edge Functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@
 /Storage/build/
 /Realtime/build/
 /Realtime/src/desktopMain/kotlin/Test.kt
+/Functions/src/desktopMain/kotlin/Test.kt
 .idea
 local.properties

--- a/Auth/src/commonMain/kotlin/io/github/jan/supacompose/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supacompose/auth/AuthImpl.kt
@@ -204,9 +204,6 @@ internal class AuthImpl(override val supabaseClient: SupabaseClient, override va
     }
 
     internal suspend fun startJob(session: UserSession, autoRefresh: Boolean = config.alwaysAutoRefresh) {
-        Napier.d {
-            "(Re)starting session job"
-        }
         if(!autoRefresh) {
             updateSession(Auth.Status.AUTHENTICATED, session)
             if(session.refreshToken.isNotBlank() && session.expiresIn != 0L) {
@@ -215,6 +212,9 @@ internal class AuthImpl(override val supabaseClient: SupabaseClient, override va
             return
         }
         if(session.expiresAt < Clock.System.now()) {
+            Napier.d {
+                "(Re)starting session job"
+            }
             try {
                 refreshSession(session.refreshToken)
             } catch(e: RestException) {
@@ -279,9 +279,6 @@ internal class AuthImpl(override val supabaseClient: SupabaseClient, override va
         _currentSession.value = newSession
         callbacks.forEach { it.invoke(newSession, oldSession) }
     }
-
-   // @OptIn(SupaComposeInternal::class)
- //   override fun path(path: String) = supabaseClient.path("auth/v${Auth.API_VERSION}/$path")
 
     override suspend fun close() {
         authScope.cancel()

--- a/Auth/src/commonMain/kotlin/io/github/jan/supacompose/auth/HttpUtils.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supacompose/auth/HttpUtils.kt
@@ -3,10 +3,13 @@ package io.github.jan.supacompose.auth
 import io.github.jan.supacompose.exceptions.RestException
 import io.ktor.client.call.body
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
-suspend fun HttpResponse.checkErrors() {
+suspend fun HttpResponse.checkErrors(error: String = "Error while performing request"): HttpResponse {
     if(status.value !in 200..299) {
-        throw RestException(status.value, "Error while performing request", body<JsonObject>().toString())
+        throw RestException(status.value, error, bodyAsText(), headers.entries().flatMap { (key, value) -> listOf(key) + value })
     }
+    return this
 }

--- a/Functions/build.gradle.kts
+++ b/Functions/build.gradle.kts
@@ -1,0 +1,75 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.android.library")
+}
+
+group = "io.github.jan-tennert.supacompose"
+version = Versions.SUPACOMPOSE
+description = "Extends Supabase with a Edge Functions Client"
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    /** Targets configuration omitted. 
+    *  To find out how to configure the targets, please follow the link:
+    *  https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#setting-up-targets */
+
+    jvm("desktop") {
+        compilations.all {
+            kotlinOptions.jvmTarget = "11"
+            kotlinOptions.freeCompilerArgs = listOf(
+                "-Xjvm-default=all",  // use default methods in interfaces,
+                "-Xlambdas=indy"      // use invokedynamic lambdas instead of synthetic classes
+            )
+        }
+    }
+    android {
+        publishLibraryVariants("release", "debug")
+    }
+    js("web", IR) {
+        browser {
+            testTask {
+                enabled = false
+                /**useKarma {
+                    useFirefox()
+                }*/
+            }
+        }
+    }
+    sourceSets {
+        all {
+            languageSettings.optIn("kotlin.RequiresOptIn")
+        }
+        val commonMain by getting {
+            dependencies {
+                api(project(":"))
+                api(project(":Supacompose-Auth"))
+                // https://mvnrepository.com/artifact/io.ktor/ktor-server-core
+            }
+        }
+        val commonTest by getting
+        val desktopMain by getting {
+            dependencies {
+                // add cio ktor client
+                api("io.ktor:ktor-client-cio:2.1.1")
+            }
+        }
+        val androidMain by getting
+        val webMain by getting
+    }
+}
+
+android {
+    compileSdk = 31
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    defaultConfig {
+        minSdk = 21
+        targetSdk = 31
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+}

--- a/Functions/src/androidMain/AndroidManifest.xml
+++ b/Functions/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="io.github.jan.supacompose.auth.library"/>

--- a/Functions/src/commonMain/kotlin/io/github/jan/supacompose/functions/EdgeFunction.kt
+++ b/Functions/src/commonMain/kotlin/io/github/jan/supacompose/functions/EdgeFunction.kt
@@ -1,0 +1,31 @@
+package io.github.jan.supacompose.functions
+
+import io.github.jan.supacompose.SupabaseClient
+import io.ktor.http.Headers
+import io.ktor.http.HeadersBuilder
+import io.ktor.http.HttpHeaders
+
+class EdgeFunction(
+    val functionName: String,
+    val headers: Headers,
+    val supabaseClient: SupabaseClient
+) {
+
+    /**
+     * Invokes the edge function
+     * Note, if you want to serialize [body] to json, you need to add the [HttpHeaders.ContentType] header yourself.
+     */
+    suspend inline operator fun <reified T> invoke(body: T) = supabaseClient.functions.invoke(functionName, body, headers)
+
+    /**
+     * Invokes the edge function
+     */
+    suspend inline operator fun invoke() = supabaseClient.functions.invoke(function = functionName, headers = headers)
+
+}
+
+class EdgeFunctionBuilder(var functionName: String = "", val headers: HeadersBuilder = HeadersBuilder(), private val supabaseClient: SupabaseClient) {
+
+    fun toEdgeFunction() = EdgeFunction(functionName, headers.build(), supabaseClient)
+
+}

--- a/Functions/src/commonMain/kotlin/io/github/jan/supacompose/functions/Functions.kt
+++ b/Functions/src/commonMain/kotlin/io/github/jan/supacompose/functions/Functions.kt
@@ -1,0 +1,91 @@
+package io.github.jan.supacompose.functions
+
+import io.github.jan.supacompose.SupabaseClient
+import io.github.jan.supacompose.auth.auth
+import io.github.jan.supacompose.auth.currentAccessToken
+import io.github.jan.supacompose.buildUrl
+import io.github.jan.supacompose.plugins.MainConfig
+import io.github.jan.supacompose.plugins.MainPlugin
+import io.github.jan.supacompose.plugins.SupacomposePluginProvider
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.appendEncodedPathSegments
+
+class Functions(override val config: Config, override val supabaseClient: SupabaseClient) : MainPlugin<Functions.Config> {
+
+    override val API_VERSION: Int
+        get() = Functions.API_VERSION
+
+    override val PLUGIN_KEY: String
+        get() = key
+
+    private val baseUrl = supabaseClient.supabaseHttpUrl.replaceFirst(".", ".functions.")
+
+    /**
+     * Invokes a remote edge function. The authorization token is automatically added to the request.
+     * Note, if you want to serialize [body] to json, you need to add the [HttpHeaders.ContentType] header yourself.
+     * @param function The function to invoke
+     * @param body The body of the request
+     * @param headers Headers to add to the request
+     */
+    suspend inline operator fun <reified T> invoke(function: String, body: T, headers: Headers = Headers.Empty): HttpResponse {
+        return supabaseClient.httpClient.post(resolveUrl(function)) {
+            this.headers.appendAll(headers)
+            body?.let {
+                setBody(body)
+            }
+            supabaseClient.auth.currentAccessToken()?.let {
+                this.headers[HttpHeaders.Authorization] = "Bearer $it"
+            }
+        }
+    }
+
+    /**
+     * Invokes a remote edge function. The authorization token is automatically added to the request.
+     * @param function The function to invoke
+     * @param headers Headers to add to the request
+     */
+    suspend inline operator fun invoke(function: String, headers: Headers = Headers.Empty): HttpResponse {
+        return supabaseClient.httpClient.post(resolveUrl(function)) {
+            this.headers.appendAll(headers)
+            supabaseClient.auth.currentAccessToken()?.let {
+                this.headers[HttpHeaders.Authorization] = "Bearer $it"
+            }
+        }
+    }
+
+    inline fun buildEdgeFunction(builder: EdgeFunctionBuilder.() -> Unit) = EdgeFunctionBuilder(supabaseClient = supabaseClient).apply(builder).toEdgeFunction()
+
+    override fun resolveUrl(path: String): String {
+        return buildUrl(config.customUrl ?: baseUrl) {
+            appendEncodedPathSegments(path)
+        }
+    }
+
+    data class Config(
+        override val customUrl: String? = null
+    ) : MainConfig
+
+    companion object : SupacomposePluginProvider<Config, Functions> {
+
+        override val key = "functions"
+        const val API_VERSION = 1
+
+        override fun create(supabaseClient: SupabaseClient, config: Config): Functions {
+            return Functions(config, supabaseClient)
+        }
+
+        override fun createConfig(init: Config.() -> Unit) = Config().apply(init)
+
+    }
+
+}
+
+/**
+ * The Functions plugin handles everything related to supabase's edge functions
+ */
+val SupabaseClient.functions: Functions
+    get() = pluginManager.getPlugin(Functions.key)

--- a/Functions/src/commonMain/kotlin/io/github/jan/supacompose/functions/Functions.kt
+++ b/Functions/src/commonMain/kotlin/io/github/jan/supacompose/functions/Functions.kt
@@ -2,17 +2,20 @@ package io.github.jan.supacompose.functions
 
 import io.github.jan.supacompose.SupabaseClient
 import io.github.jan.supacompose.auth.auth
+import io.github.jan.supacompose.auth.checkErrors
 import io.github.jan.supacompose.auth.currentAccessToken
 import io.github.jan.supacompose.buildUrl
 import io.github.jan.supacompose.plugins.MainConfig
 import io.github.jan.supacompose.plugins.MainPlugin
 import io.github.jan.supacompose.plugins.SupacomposePluginProvider
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.appendEncodedPathSegments
+import io.ktor.util.appendAll
 
 class Functions(override val config: Config, override val supabaseClient: SupabaseClient) : MainPlugin<Functions.Config> {
 
@@ -26,20 +29,29 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
 
     /**
      * Invokes a remote edge function. The authorization token is automatically added to the request.
+     * @param function The function to invoke
+     * @param builder The request builder to configure the request
+     */
+    suspend inline operator fun invoke(function: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse {
+        return supabaseClient.httpClient.post(resolveUrl(function)) {
+            supabaseClient.auth.currentAccessToken()?.let {
+                this.headers[HttpHeaders.Authorization] = "Bearer $it"
+            }
+            builder()
+        }.checkErrors("Couldn't invoke function $function")
+    }
+
+    /**
+     * Invokes a remote edge function. The authorization token is automatically added to the request.
      * Note, if you want to serialize [body] to json, you need to add the [HttpHeaders.ContentType] header yourself.
      * @param function The function to invoke
      * @param body The body of the request
      * @param headers Headers to add to the request
      */
-    suspend inline operator fun <reified T> invoke(function: String, body: T, headers: Headers = Headers.Empty): HttpResponse {
-        return supabaseClient.httpClient.post(resolveUrl(function)) {
-            this.headers.appendAll(headers)
-            body?.let {
-                setBody(body)
-            }
-            supabaseClient.auth.currentAccessToken()?.let {
-                this.headers[HttpHeaders.Authorization] = "Bearer $it"
-            }
+    suspend inline operator fun <reified T> invoke(function: String, body: T, headers: Headers = Headers.Empty): HttpResponse = invoke(function) {
+        this.headers.appendAll(headers)
+        body?.let {
+            setBody(body)
         }
     }
 
@@ -48,15 +60,13 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
      * @param function The function to invoke
      * @param headers Headers to add to the request
      */
-    suspend inline operator fun invoke(function: String, headers: Headers = Headers.Empty): HttpResponse {
-        return supabaseClient.httpClient.post(resolveUrl(function)) {
-            this.headers.appendAll(headers)
-            supabaseClient.auth.currentAccessToken()?.let {
-                this.headers[HttpHeaders.Authorization] = "Bearer $it"
-            }
-        }
+    suspend inline operator fun invoke(function: String, headers: Headers = Headers.Empty): HttpResponse = invoke(function) {
+        this.headers.appendAll(headers)
     }
 
+    /**
+     * Builds an [EdgeFunction] which can be invoked multiple times
+     */
     inline fun buildEdgeFunction(builder: EdgeFunctionBuilder.() -> Unit) = EdgeFunctionBuilder(supabaseClient = supabaseClient).apply(builder).toEdgeFunction()
 
     override fun resolveUrl(path: String): String {

--- a/README.md
+++ b/README.md
@@ -549,6 +549,41 @@ channel.track(PresenceData(2, "Example")) //send your "state"/presence to other 
 
 </details>
 
+#### Functions (Edge Functions)
+<details><summary>Execute edge functions directly</summary>
+
+```kotlin
+@Serializable
+data class SomeData(val name: String)
+
+val response: HttpResponse = client.functions("test")
+//with body
+val response: HttpResponse = client.functions(
+    function = "test",
+    body = SomeData("Name")
+    headers = Headers.build {
+        append(HttpHeaders.ContentType, "application/json")
+    }
+)
+```
+</details>
+<details><summary>Store your edge function in a variable</summary>
+
+```kotlin
+@Serializable
+data class SomeData(val name: String)
+
+val testFunction: EdgeFunction = client.functions.buildEdgeFunction {
+    functionName = "test"
+    headers.append(HttpHeaders.ContentType, "application/json")
+}
+
+val response: HttpResponse = testFunction()
+//with body
+val response: HttpResponse = testFunction(SomeData("Name"))
+```
+</details>
+
 
 # Credits 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
  //   id("org.jetbrains.compose") version Versions.COMPOSE
 }
 
-val modules = listOf("Supacompose", "Supacompose-Auth", "Supacompose-Postgrest", "Supacompose-Storage", "Supacompose-Realtime")
+val modules = listOf("Supacompose", "Supacompose-Auth", "Supacompose-Postgrest", "Supacompose-Storage", "Supacompose-Realtime", "Supacompose-Functions")
 
 allprojects {
     repositories {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,7 +6,7 @@ object Versions {
     const val COROUTINES = "1.6.4"
     const val DOKKA = "1.7.10"
     const val NEXUS_STAGING = "0.30.0"
-    const val SUPACOMPOSE = "0.4.0"
+    const val SUPACOMPOSE = "0.3.0"
     const val ANDROID_COMPAT = "1.5.1"
     const val COMPOSE = "1.2.0-alpha01-dev686"
     const val NAPIER = "2.6.1"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,7 +6,7 @@ object Versions {
     const val COROUTINES = "1.6.4"
     const val DOKKA = "1.7.10"
     const val NEXUS_STAGING = "0.30.0"
-    const val SUPACOMPOSE = "0.3.0"
+    const val SUPACOMPOSE = "0.4.0"
     const val ANDROID_COMPAT = "1.5.1"
     const val COMPOSE = "1.2.0-alpha01-dev686"
     const val NAPIER = "2.6.1"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,9 +21,11 @@ include("Postgrest")
 //include(":webDemo")
 include("Storage")
 include("Realtime")
+include("Functions")
 project(":Auth").name = "Supacompose-Auth"
 project(":Postgrest").name = "Supacompose-Postgrest"
 project(":Storage").name = "Supacompose-Storage"
 project(":Realtime").name = "Supacompose-Realtime"
+project(":Functions").name = "Supacompose-Functions"
 rootProject.name = "Supacompose"
 

--- a/src/commonMain/kotlin/io/github/jan/supacompose/exceptions/RestException.kt
+++ b/src/commonMain/kotlin/io/github/jan/supacompose/exceptions/RestException.kt
@@ -1,3 +1,3 @@
 package io.github.jan.supacompose.exceptions
 
-class RestException(val status: Int, val error: String, description: String, headers: List<String> = emptyList()) : Exception("$description (HTTP status $status) Headers: $headers")
+class RestException(val status: Int, val error: String, description: String, headers: List<String> = emptyList()) : Exception("$error: $description (HTTP status $status) \nHeaders: $headers")


### PR DESCRIPTION
This pr adds support for https://supabase.com/docs/guides/functions

With edge functions, you can deploy own typescript functions to supabase and execute them remotely.

The current syntax looks like this:

**Add Functions plugin to supabase**
```kotlin
val client = createSupabaseClient {
    [...]
    
    install(Auth)
    install(Functions)
}

//some serializable data
@Serializable
data class SomeData(val name: String)
```

**Execute functions directly**
```kotlin
val response: HttpResponse = client.functions("test")
//with body
val response: HttpResponse = client.functions(
    function = "test",
    body = SomeData("Name")
    headers = Headers.build {
        append(HttpHeaders.ContentType, "application/json") 
    }
)
```
**Store your function in a variable**
```kotlin
val testFunction: EdgeFunction = client.functions.buildEdgeFunction {
    functionName = "test"
    headers.append(HttpHeaders.ContentType, "application/json")
}

val response: HttpResponse = testFunction()
//with body
val response: HttpResponse = testFunction(SomeData("Name"))
```    